### PR TITLE
Added request to the dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "morx": "0.0.5",
     "node-forge": "0.7.1",
     "q": "1.5.0",
+    "request": "^2.88.2",
     "sha.js": "2.4.8"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes the error thrown due to missing module(request) anytime any of the APIs are called. https://github.com/Flutterwave/Flutterwave-node-v3/issues/11#issue-652453373
I added **request module** as a dependency in the package.json.