### PR TITLE
update account name resolution service

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ const flw = new Flutterwave(PUBLIC_KEY, SECRET_KEY);
 *  Get balances per currency
 *   Fetch a beneficiary
 *   Get a virtual account number
+*   Resolve account number
 
 **9**. **BENEFICIARIES** 
 

--- a/services/misc/rave.resolve.account.js
+++ b/services/misc/rave.resolve.account.js
@@ -6,6 +6,8 @@ const package = require('../../package.json');
 const spec = morx.spec()
 	.build('account_bank', 'required:true, eg:044')
 	.build('account_number', 'required:true,validators:isNumeric, eg:06900021')
+	.build('country', 'required:false, eg:KE')
+	.build('type', 'required:false, eg:MOBILEMONEY')
 	.end();
 
 


### PR DESCRIPTION
This PR is to allow account resolution to work for other countries and other account entity types e.g BANKACCOUNT or MOBILEMONEY entity.
